### PR TITLE
Add sanitize.css to project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "node-sass": "^4.5.3",
     "precommit": "^1.2.2",
     "rimraf": "^2.6.1",
+    "sanitize.css": "^5.0.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
     "stylelint": "^8.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 
 import App from './components/App'
 
+import 'sanitize.css/sanitize.css'
 import './styles/style.scss'
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,5 +1,4 @@
 @import './base/**/*';
-
 @import './mixins/**/*';
 @import './components/**/*';
 @import './forms/**/*';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4912,6 +4912,10 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+sanitize.css@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-5.0.0.tgz#84184b40678f72bb8898c768a27be7578257271a"
+
 sass-graph@^2.1.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"


### PR DESCRIPTION
I didn't find the integration of `sanitize.css` package with __Webpack__ through `@import` statement twice straightforward, so I figured I'd share.

Basically, what `~` in the statement does is that it grabs the CSS module from its package stored in `node_modules` folder.