### PR TITLE
Add interpolate flag to html-loader

### DIFF
--- a/internals/webpack/config.base.js
+++ b/internals/webpack/config.base.js
@@ -15,6 +15,10 @@ module.exports = options => ({
   module: {
     rules: [
       {
+        test: /\.html$/,
+        use: ['html-loader?interpolate'],
+      },
+      {
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'babel-loader',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint": "^4.2.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
-    "html-loader": "^0.4.5",
+    "html-loader": "^0.5.1",
     "html-webpack-plugin": "^2.29.0",
     "import-glob-loader": "^1.1.0",
     "lint-staged": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,9 +2732,9 @@ html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
-html-loader@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.4.5.tgz#5fbcd87cd63a5c49a7fce2fe56f425e05729c68c"
+html-loader@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.5.1.tgz#4f1e8396a1ea6ab42bedc987dfac058070861ebe"
   dependencies:
     es6-templates "^0.2.2"
     fastparse "^1.1.1"


### PR DESCRIPTION
Allows for HTML template files to be required within one another.
Markup can be then decomposed into smaller more manageable chunks,
and put back together with `${require('./path/file.html')}` syntax.