### PR TITLE
Update Webpack base config file

### DIFF
--- a/internals/webpack/config.base.js
+++ b/internals/webpack/config.base.js
@@ -35,7 +35,6 @@ module.exports = options => ({
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
           use: ['css-loader'],
-          disable: process.env.NODE_ENV === 'development',
         }),
       },
     ],
@@ -50,7 +49,10 @@ module.exports = options => ({
       },
     }),
     new webpack.NamedModulesPlugin(),
-    new ExtractTextPlugin('style.[hash].css'),
+    new ExtractTextPlugin({
+      filename: 'style.[hash].css',
+      disable: process.env.NODE_ENV === 'development',
+    }),
   ]),
   resolve: {
     modules: ['src', 'node_modules'],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "webpack -p --config=internals/webpack/config.prod.js --progress",
     "build:clean": "rimraf ./dist",
     "stage": "webpack-dev-server --config=internals/webpack/config.prod.js -p --open",
-    "dev": "webpack-dev-server --config=internals/webpack/config.dev.js --open",
+    "dev": "NODE_ENV=development webpack-dev-server --config=internals/webpack/config.dev.js --open",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "lint:css": "stylelint './src/**/*.js'",


### PR DESCRIPTION
Fixes conditional usage of `extract-text-webpack-plugin` based on NODE_ENV variable. Setting of `disable` field is only valid in the constructor.

https://github.com/webpack-contrib/extract-text-webpack-plugin/blob/master/README.md#options